### PR TITLE
Inspecting upgrade failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
         <acceptance.test.parallel.count>4</acceptance.test.parallel.count>
         <cucumber.version>1.2.5</cucumber.version>
         <cucumber.jvm.parallel.version>1.0.1</cucumber.jvm.parallel.version>
-        <spring.version>4.2.5.RELEASE</spring.version>
-        <assertj.version>3.3.0</assertj.version>
+        <spring.version>5.0.8.RELEASE</spring.version>
+        <assertj.version>3.10.0</assertj.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,10 @@
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <acceptance.test.parallel.count>4</acceptance.test.parallel.count>
         <cucumber.version>1.2.5</cucumber.version>
-        <cucumber.jvm.parallel.version>1.0.1</cucumber.jvm.parallel.version>
+        <cucumber.jvm.parallel.version>5.0.0</cucumber.jvm.parallel.version>
         <spring.version>5.0.8.RELEASE</spring.version>
         <assertj.version>3.10.0</assertj.version>
+        <java.version>1.8</java.version>
     </properties>
 
     <build>
@@ -34,8 +35,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,6 @@
     <description>Reactor project for the test automation quickstart</description>
 
     <properties>
-        <cucumber.version>1.2.5</cucumber.version>
-        <cucumber.jvm.parallel.version>4.2.0</cucumber.jvm.parallel.version>
-        <spring.version>5.0.8.RELEASE</spring.version>
-        <assertj.version>3.10.0</assertj.version>
         <javamail.version>1.4.4</javamail.version>
         <selenium.version>3.13.0</selenium.version>
         <jackson.version>2.9.6</jackson.version>
@@ -25,6 +21,10 @@
         <zap.clientapi.version>1.6.0</zap.clientapi.version>
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <acceptance.test.parallel.count>4</acceptance.test.parallel.count>
+        <cucumber.version>1.2.5</cucumber.version>
+        <cucumber.jvm.parallel.version>1.0.1</cucumber.jvm.parallel.version>
+        <spring.version>4.2.5.RELEASE</spring.version>
+        <assertj.version>3.3.0</assertj.version>
     </properties>
 
     <build>

--- a/ui-acceptance-tests/pom.xml
+++ b/ui-acceptance-tests/pom.xml
@@ -19,14 +19,16 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>
                         <configuration>
                             <!-- Mandatory -->
                             <!-- comma separated list of package names to scan for glue code -->
-                            <glue>com.opencredo.test.ui.acceptance.test.step.definitions</glue>
+                            <glue>
+                                <package>com.opencredo.test.ui.acceptance.test.step.definitions</package>
+                            </glue>
                             <!-- These are the default values -->
                             <!-- Where to output the generated Junit tests -->
                             <outputDirectory>${project.build.directory}/generated-test-sources/cucumber
@@ -42,7 +44,10 @@
                             <!-- CucumberOptions.monochrome property -->
                             <monochrome>true</monochrome>
                             <!-- The tags to run, maps to CucumberOptions.tags property -->
-                            <tags>"@ui-demo-parallel","~@ignore"</tags>
+                            <tags>
+                                <tag>@ui-demo-parallel</tag>
+                                <tag>~@ignore</tag>
+                            </tags>
                             <!-- If set to true, only feature files containing the required tags shall be generated. -->
                             <!-- Excluded tags (~@notMe) are ignored. -->
                         </configuration>

--- a/ui-acceptance-tests/src/test/resources/cucumber/ParallelUiTest2.feature
+++ b/ui-acceptance-tests/src/test/resources/cucumber/ParallelUiTest2.feature
@@ -11,8 +11,8 @@ Feature: Demonstrate the UI test framework parallel capability
     When I search for "OpenCredo"
     Then the site "www.opencredo.com" should be present in the results
 
-
-  Scenario: Another simple interaction with a web page
+  @failing
+  Scenario: A failing interaction with a web page
     Given I am on the Google search page
     When I search for "OpenCredo"
     Then the site "www.opencredo2.com" should be present in the results

--- a/ui-acceptance-tests/src/test/resources/cucumber/ParallelUiTest3.feature
+++ b/ui-acceptance-tests/src/test/resources/cucumber/ParallelUiTest3.feature
@@ -22,7 +22,8 @@ Feature: Demonstrate the UI test framework parallel capability
     When I search for "OpenCredo"
     Then the site "www.opencredo.com" should be present in the results
 
-  Scenario: Another simple interaction with a web page
+  @failing
+  Scenario: A failing interaction with a web page
     Given I am on the Google search page
     When I search for "OpenCredo"
     Then the site "www.opencredo2.com" should be present in the results


### PR DESCRIPTION
Bisected the upgrades, as it turns out one of them caused the ui tests not to run. Turns out the POM was configured wrongly for the update of Cucumber JVM parallel.

Should work okay now.